### PR TITLE
Preserve system error messages if creation fails

### DIFF
--- a/lua/cothread/socket.lua
+++ b/lua/cothread/socket.lua
@@ -44,13 +44,11 @@ end
 
 local CoSocket = {}
 local function wrap(socket, ...)
-	if not socket then
-		return nil, ...
-	elseif type(socket) == "userdata" then
+	if type(socket) == "userdata" then
 		socket:settimeout(0)
 		socket = copy(CoSocket, Wrapper{ __object = socket })
 	end
-	return socket
+	return socket, ...
 end
 
 

--- a/lua/cothread/socket.lua
+++ b/lua/cothread/socket.lua
@@ -43,8 +43,10 @@ local function trywait(self, socket, op)
 end
 
 local CoSocket = {}
-local function wrap(socket)
-	if type(socket) == "userdata" then
+local function wrap(socket, ...)
+	if not socket then
+		return nil, ...
+	else type(socket) == "userdata" then
 		socket:settimeout(0)
 		socket = copy(CoSocket, Wrapper{ __object = socket })
 	end

--- a/lua/cothread/socket.lua
+++ b/lua/cothread/socket.lua
@@ -46,7 +46,7 @@ local CoSocket = {}
 local function wrap(socket, ...)
 	if not socket then
 		return nil, ...
-	else type(socket) == "userdata" then
+	elseif type(socket) == "userdata" then
 		socket:settimeout(0)
 		socket = copy(CoSocket, Wrapper{ __object = socket })
 	end


### PR DESCRIPTION
When original socket.tcp fails it returns nil and an error message from the underlying system.
The cothread.socket wrap function must not discard those messages.
